### PR TITLE
Add rollupResolveOptions

### DIFF
--- a/.eleventy.ts
+++ b/.eleventy.ts
@@ -3,7 +3,7 @@
 import path from 'path';
 import { Plugin, rollup } from 'rollup';
 import svelte, { Options as SvelteOptions } from 'rollup-plugin-svelte';
-import resolve from '@rollup/plugin-node-resolve';
+import resolve, { RollupNodeResolveOptions } from '@rollup/plugin-node-resolve';
 import virtual from '@rollup/plugin-virtual';
 import cheerio from 'cheerio';
 
@@ -18,6 +18,7 @@ type Options = {
 	rollupPluginSvelteOptions?: Partial<SvelteOptions>;
 	rollupInputPlugins?: Plugin[];
 	rollupOutputPlugins?: Plugin[];
+	rollupResolveOptions?: Partial<RollupNodeResolveOptions>;
 };
 
 export default function (
@@ -26,7 +27,8 @@ export default function (
 		svelteDir = '',
 		rollupPluginSvelteOptions = {},
 		rollupInputPlugins = [],
-		rollupOutputPlugins = []
+		rollupOutputPlugins = [],
+		rollupResolveOptions = {}
 	}: Options
 ) {
 	let componentMap: ComponentMap = {};
@@ -75,7 +77,7 @@ export default function (
 						virtual({
 							entry: virtualEntry(componentMap[outputPath])
 						}) as Plugin,
-						resolve(),
+						resolve(rollupResolveOptions),
 						svelte({
 							emitCss: false,
 							...rollupPluginSvelteOptions

--- a/example/.eleventy.js
+++ b/example/.eleventy.js
@@ -11,7 +11,9 @@ module.exports = function (eleventyConfig) {
 		// Array of Rollup input plugins. (Optional)
 		rollupInputPlugins: [],
 		// Array of Rollup output plugins. (Optional)
-		rollupOutputPlugins: [terser()]
+		rollupOutputPlugins: [terser()],
+		// Options that you may pass to @rollup/plugin-node-resolve. (Optional)
+		rollupResolveOptions: {}
 	});
 
 	return {


### PR DESCRIPTION
I've added options for @rollup/plugin-node-resolve.
This change makes users possible to pass options to @rollup/plugin-node-resolve which is executed by this plugin.

When I add `resolve({browser: true})` to `rollupInputPlugins`, it will be executed after `resolve()` and the option`{browser: true}` has no effect. Therefore, I suppose it would be useful to allow users to pass options to default `resolve()`.