### PR TITLE
Allow for greater configuration of this plugin's internal Rollup build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ dist
 # End of https://www.toptal.com/developers/gitignore/api/node
 
 _site/
+play/

--- a/example/.eleventy.js
+++ b/example/.eleventy.js
@@ -1,17 +1,12 @@
 const embedSvelte = require('../');
 const sveltePreprocess = require('svelte-preprocess'); // Optional
-const { terser } = require('rollup-plugin-terser'); // Optional
 
 module.exports = function (eleventyConfig) {
 	eleventyConfig.addPlugin(embedSvelte, {
 		// Directory that hosts your *.svelte component files. (Optional)
 		svelteDir: './svelte',
 		// Options that you may pass to rollup-plugin-svelte. (Optional)
-		rollupPluginSvelteOptions: { preprocess: sveltePreprocess() },
-		// Array of Rollup input plugins. (Optional)
-		rollupInputPlugins: [],
-		// Array of Rollup output plugins. (Optional)
-		rollupOutputPlugins: [terser()]
+		rollupPluginSvelteOptions: { preprocess: sveltePreprocess() }
 	});
 
 	return {

--- a/example/rollup.config.js
+++ b/example/rollup.config.js
@@ -1,0 +1,15 @@
+// This file is optional. If present, this plugin will load it and
+// look for the config with the input 'embedSvelte' and use the
+// corresponding Rollup configuration while bundling Svelte components.
+
+const { terser } = require('rollup-plugin-terser');
+
+export default {
+	input: 'embedSvelte',
+	// Additional input plugins (Optional)
+	plugins: [],
+	output: {
+		// Additional output plugins (Optional)
+		plugins: [terser()]
+	}
+};

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
 	"main": "dist/.eleventy.js",
 	"types": "dist/.eleventy.d.ts",
 	"dependencies": {
-		"@rollup/plugin-node-resolve": "^13.0.0",
 		"@rollup/plugin-virtual": "^2.0.3",
 		"cheerio": "^1.0.0-rc.9",
-		"rollup": "2.48.0",
 		"rollup-plugin-svelte": "^7.1.0"
 	},
 	"peerDependencies": {
+		"@rollup/plugin-node-resolve": ">=13.0.0",
+		"rollup": ">=2.48.0",
 		"svelte": ">=3.38.0"
 	},
 	"devDependencies": {

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -1,0 +1,96 @@
+import path from 'path';
+import type { OutputOptions, Plugin, RollupOptions } from 'rollup';
+//@ts-ignore
+import loadConfigFile from 'rollup/dist/loadConfigFile';
+
+type RollupConfig = RollupOptions & { output: OutputOptions[] };
+
+const CONFIG_FILE_PATH = 'rollup.config.js';
+
+export async function getRollupOptions(input: string): Promise<{
+	inputOptions: ReturnType<typeof getRollupInputOptions>;
+	outputOptions: ReturnType<typeof getRollupOutputOptions>;
+}> {
+	const configOptions = await getConfigFile();
+
+	if (!configOptions) {
+		return {
+			inputOptions: getRollupInputOptions({}),
+			outputOptions: getRollupOutputOptions({})
+		};
+	}
+
+	const options = configOptions.find((o) => o.input === input);
+
+	if (!options) {
+		throw new Error(
+			`No config found in ${CONFIG_FILE_PATH} for input: ${input}`
+		);
+	}
+
+	if (options.output.length > 1) {
+		throw new Error(
+			`An array of output options is not supported for input: ${input}`
+		);
+	}
+
+	const { output, ...inputOptions } = options;
+	const [outputOptions] = output;
+
+	return {
+		inputOptions: getRollupInputOptions(inputOptions),
+		outputOptions: getRollupOutputOptions(outputOptions)
+	};
+}
+
+async function getConfigFile(): Promise<RollupConfig[] | void> {
+	try {
+		const {
+			options,
+			warnings
+		}: {
+			options: RollupConfig[];
+			warnings: { flush: Function };
+		} = await loadConfigFile(path.resolve(CONFIG_FILE_PATH));
+		// This prints all deferred warnings
+		warnings.flush();
+		return options;
+	} catch {}
+}
+
+function getRollupInputOptions(configOptions: RollupOptions) {
+	return (defaultInputOptions: RollupOptions = {}): RollupOptions => {
+		const inputPlugins = mergePlugins(
+			defaultInputOptions.plugins ?? [],
+			configOptions.plugins ?? []
+		);
+		return { ...defaultInputOptions, ...configOptions, plugins: inputPlugins };
+	};
+}
+
+function getRollupOutputOptions(configOptions: OutputOptions) {
+	return (defaultOutputOptions: OutputOptions = {}): OutputOptions => {
+		const outputPlugins = mergePlugins(
+			defaultOutputOptions.plugins ?? [],
+			configOptions.plugins ?? []
+		);
+		return {
+			...defaultOutputOptions,
+			...configOptions,
+			plugins: outputPlugins
+		};
+	};
+}
+
+/** Merge Rollup Plugin arrays. Later arrays take precedence. */
+function mergePlugins(...pluginsArrays: Plugin[][]): Plugin[] {
+	const pluginsObjects: Record<string, Plugin>[] = pluginsArrays.map(
+		(plugins) =>
+			plugins.reduce(
+				(pluginsObject: Record<string, Plugin>, plugin: Plugin) =>
+					Object.assign(pluginsObject, { [plugin.name]: plugin }),
+				{}
+			)
+	);
+	return Object.values(Object.assign({}, ...pluginsObjects));
+}


### PR DESCRIPTION
## Overview
I thought it would be neat to allow users of this plugin to configure the internal Rollup build as much as possible. At the same time, I don't want to add individual configuration properties for each and every Rollup option there is. What better way to enable extensibility than through an actual `rollup.config.js` file?

## This PR does the following:
- Removes the `rollupInputPlugins` and `rollupOutputPlugins` plugin options
- If present, reads the `rollup.config.js` file and uses it (as much as possible) when building Svelte components

## Still haven't figured out:
- How to remove the `rollupPluginSvelteOptions` option as well and enable configuration of `rollup-plugin-svelte` in the `rollup.config.js` file.